### PR TITLE
feat: add ChatGPT API integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ This folder explains the Win32 pieces used in this project and how the Zig + C b
 - win32-overview.md — What the code does in Win32 terms (class, window, message loop, painting).
 - build-and-linking.md — How `build.zig` compiles and links Zig + C and picks the subsystem.
 - troubleshooting.md — Common pitfalls (e.g., no window appears) and debugging tips.
+- chatgpt.md — Example of calling the OpenAI ChatGPT API from Zig.
 

--- a/docs/chatgpt.md
+++ b/docs/chatgpt.md
@@ -1,0 +1,11 @@
+ChatGPT Integration
+===================
+
+`src/chatgpt.zig` demonstrates how to invoke the OpenAI ChatGPT API from Zig. It reads the API key from the `OPENAI_API_KEY` environment variable and sends a simple message.
+
+```
+const api_key = std.process.getEnvVarOwned(allocator, "OPENAI_API_KEY") catch return;
+const response = try chatgpt.chatCompletion(allocator, api_key, "Hello from Zig!");
+```
+
+The raw JSON response from the API is printed to stdout.

--- a/src/chatgpt.zig
+++ b/src/chatgpt.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+
+pub fn chatCompletion(allocator: std.mem.Allocator, api_key: []const u8, prompt: []const u8) ![]u8 {
+    var client = std.http.Client{ .allocator = allocator };
+    defer client.deinit();
+
+    var auth_header = try std.fmt.allocPrint(allocator, "Bearer {s}", .{ api_key });
+    defer allocator.free(auth_header);
+
+    var req = try client.request(.{
+        .method = .POST,
+        .url = "https://api.openai.com/v1/chat/completions",
+        .headers = &.{
+            .{ .name = "Content-Type", .value = "application/json" },
+            .{ .name = "Authorization", .value = auth_header },
+        },
+    });
+    defer req.deinit();
+
+    const body = try std.fmt.allocPrint(allocator,
+        "{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\"{s}\"}]}",
+        .{ prompt },
+    );
+    defer allocator.free(body);
+
+    try req.writeAll(body);
+    try req.finish();
+
+    const resp_body = try req.readToEndAlloc(allocator, 1024 * 1024);
+    return resp_body;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@
 //! - Demonstrates calling C functions from Zig using @cImport
 //! - Shows a simple Win32 window via a C helper implementation
 const std = @import("std");
+const chatgpt = @import("chatgpt.zig");
 
 // Import C headers so their functions are available as `c.*` in Zig.
 // c_functions.h: simple arithmetic example (uses libc printf)
@@ -12,15 +13,19 @@ const c = @cImport({
 });
 
 pub fn main() anyerror!void {
-    // If you need to debug via console output, consider temporarily
-    // switching the subsystem to .Console in build.zig.
-    // const print = std.debug.print;
+    const allocator = std.heap.page_allocator;
+    const stdout = std.io.getStdOut().writer();
 
-    // Example: call a C function from Zig.
-    // const num1: c_int = 10;
-    // const num2: c_int = 5;
-    // const result_from_c = c.add_in_c(num1, num2);
-    // print("[Zig] Result from C: {d}\n", .{result_from_c});
+    const api_key = std.process.getEnvVarOwned(allocator, "OPENAI_API_KEY") catch {
+        try stdout.print("OPENAI_API_KEY not set\n", .{});
+        return;
+    };
+    defer allocator.free(api_key);
+
+    const response = try chatgpt.chatCompletion(allocator, api_key, "Hello from Zig!");
+    defer allocator.free(response);
+
+    try stdout.print("ChatGPT raw response: {s}\n", .{response});
 
     // Create a simple Win32 window via C and run the message loop.
     _ = c.CreateSimpleWindow();


### PR DESCRIPTION
## Summary
- add `chatgpt.zig` module for calling OpenAI's ChatGPT API
- invoke ChatGPT request from `main.zig` and print raw JSON
- document ChatGPT example usage

## Testing
- `zig build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b36dfbfc83328982f847b293128a