### PR TITLE
Add Gemini API module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -52,6 +52,13 @@ pub fn build(b: *std.Build) void {
     });
     exe.root_module.addImport("openai", openai_mod);
 
+    const gemini_mod = b.addModule("gemini", .{
+        .root_source_file = b.path("src/gemini/mod.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("gemini", gemini_mod);
+
     // Build as a GUI subsystem app so no console is attached
     exe.subsystem = .Windows;
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,10 @@ Layout
   - mod.zig — public entry re-exporting submodules
   - chatgpt.zig — Chat Completions helpers
   - models.zig — Models listing and parsing helpers
+- src/gemini/ — Gemini-related Zig code
+  - mod.zig — public entry re-exporting submodules
+  - generate.zig — Text generation helpers
+  - models.zig — Models listing and parsing helpers
 - src/platform/ — platform adapters and native implementations
   - ui.zig — Win32 UI adapter (message box, API key prompt, create window)
   - http.zig — HTTP adapter (WinINet GET with headers)
@@ -29,7 +33,7 @@ Layout
 
 Build Wiring
 ------------
-- `build.zig` registers the OpenAI module and compiles platform C code.
+- `build.zig` registers the OpenAI and Gemini modules and compiles platform C code.
 - C headers in `inc/` are made available via `exe.addIncludePath`.
 - System libraries linked: `user32`, `gdi32`, `wininet`, `crypt32`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,5 @@ This folder explains the Win32 pieces, the Zig + C build, the platform adapter l
 - build-and-linking.md — How `build.zig` compiles/links Zig + C and selects subsystem.
 - troubleshooting.md — Common pitfalls (e.g., no window appears) and debugging tips.
 - chatgpt.md — Example of calling OpenAI Chat Completions from Zig.
+- gemini.md — Example of calling Gemini API from Zig.
 

--- a/docs/build-and-linking.md
+++ b/docs/build-and-linking.md
@@ -36,11 +36,15 @@ Zig ↔ C Interop
 
 Named Zig Modules
 -----------------
-- The build registers a named module `openai` for API helpers:
-  - Registration in `build.zig`:
+- The build registers named modules for API helpers:
+  - OpenAI:
     - `const openai_mod = b.addModule("openai", .{ .root_source_file = b.path("src/openai/mod.zig"), ... });`
     - `exe.root_module.addImport("openai", openai_mod);`
-  - Usage from Zig: `const openai = @import("openai");`
+    - Usage: `const openai = @import("openai");`
+  - Gemini:
+    - `const gemini_mod = b.addModule("gemini", .{ .root_source_file = b.path("src/gemini/mod.zig"), ... });`
+    - `exe.root_module.addImport("gemini", gemini_mod);`
+    - Usage: `const gemini = @import("gemini");`
 
 Artifacts
 ---------

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -1,0 +1,31 @@
+Gemini API Integration
+======================
+
+The Gemini helpers live under `src/gemini/` and are exposed via the named module `gemini`.
+
+Setup
+-----
+- API Key: set `GEMINI_API_KEY` in your environment or provide it directly to the helper functions.
+- Optional: set `GEMINI_MODEL` (defaults to `gemini-1.5-flash`).
+
+Usage
+-----
+```
+const std = @import("std");
+const gemini = @import("gemini");
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+    const api_key = try std.process.getEnvVarOwned(allocator, "GEMINI_API_KEY");
+    defer allocator.free(api_key);
+
+    const resp = try gemini.generateContentWithEnvModel(allocator, api_key, "Hello from Zig!");
+    defer allocator.free(resp);
+    // resp is a JSON string from the Gemini API
+}
+```
+
+Notes
+-----
+- To use a specific model without an env var, call `gemini.generateContent(alloc, api_key, "gemini-1.5-flash", prompt)`.
+- See also: `src/gemini/models.zig` for listing available models and `docs/build-and-linking.md` for how the `gemini` module is wired in `build.zig`.

--- a/src/gemini/generate.zig
+++ b/src/gemini/generate.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+/// Calls Gemini's text generation API.
+/// model: pass any available model id (e.g., "gemini-1.5-flash").
+/// prompt: user content. Properly JSON-escaped before sending.
+pub fn generateContent(
+    allocator: std.mem.Allocator,
+    api_key: []const u8,
+    model: []const u8,
+    prompt: []const u8,
+) ![]u8 {
+    var client = std.http.Client{ .allocator = allocator };
+    defer client.deinit();
+
+    const url = try std.fmt.allocPrint(
+        allocator,
+        "https://generativelanguage.googleapis.com/v1beta/models/{s}:generateContent?key={s}",
+        .{ model, api_key },
+    );
+    defer allocator.free(url);
+
+    var req = try client.request(.{
+        .method = .POST,
+        .url = url,
+        .headers = &.{
+            .{ .name = "Content-Type", .value = "application/json" },
+        },
+    });
+    defer req.deinit();
+
+    // Escape the prompt as a JSON string (includes quotes)
+    const escaped_prompt = try std.json.stringifyAlloc(allocator, prompt, .{});
+    defer allocator.free(escaped_prompt);
+
+    const body = try std.fmt.allocPrint(
+        allocator,
+        "{{\"contents\":[{{\"parts\":[{{\"text\":{s}}}]}}]}}",
+        .{ escaped_prompt },
+    );
+    defer allocator.free(body);
+
+    try req.writeAll(body);
+    try req.finish();
+
+    const resp_body = try req.readToEndAlloc(allocator, 1024 * 1024);
+    return resp_body;
+}
+
+/// Helper that chooses model from GEMINI_MODEL env var or defaults to gemini-1.5-flash.
+pub fn generateContentWithEnvModel(
+    allocator: std.mem.Allocator,
+    api_key: []const u8,
+    prompt: []const u8,
+) ![]u8 {
+    var model_buf = std.ArrayList(u8).init(allocator);
+    defer model_buf.deinit();
+
+    const env_model = std.process.getEnvVarOwned(allocator, "GEMINI_MODEL") catch null;
+    if (env_model) |m| {
+        defer allocator.free(m);
+        try model_buf.appendSlice(m);
+    } else {
+        try model_buf.appendSlice("gemini-1.5-flash");
+    }
+
+    return try generateContent(allocator, api_key, model_buf.items, prompt);
+}

--- a/src/gemini/mod.zig
+++ b/src/gemini/mod.zig
@@ -1,0 +1,10 @@
+// Public entry for the Gemini helpers.
+// Re-export submodules so callers can `@import("gemini")` and access APIs.
+pub const generate = @import("generate.zig");
+pub const models = @import("models.zig");
+
+// Convenience re-exports
+pub const generateContent = generate.generateContent;
+pub const generateContentWithEnvModel = generate.generateContentWithEnvModel;
+pub const fetchModelsJson = models.fetchModelsJson;
+pub const extractModelIds = models.extractModelIds;

--- a/src/gemini/models.zig
+++ b/src/gemini/models.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+
+pub const ModelsResponse = struct {
+    status: std.http.Status,
+    body: []u8,
+};
+
+/// Fetches the raw models list JSON from Gemini API.
+/// Caller owns the returned body and must free it.
+pub fn fetchModelsJson(allocator: std.mem.Allocator, api_key: []const u8) !ModelsResponse {
+    var client = std.http.Client{ .allocator = allocator };
+    defer client.deinit();
+
+    const url = try std.fmt.allocPrint(
+        allocator,
+        "https://generativelanguage.googleapis.com/v1beta/models?key={s}",
+        .{ api_key },
+    );
+    defer allocator.free(url);
+
+    var req = try client.request(.{
+        .method = .GET,
+        .url = url,
+    });
+    defer req.deinit();
+
+    try req.finish();
+    const status = req.response.status;
+    const body = try req.readToEndAlloc(allocator, 1024 * 1024);
+    return .{ .status = status, .body = body };
+}
+
+/// Extracts model ids from Gemini models JSON response.
+/// Returns a heap-allocated array of heap-allocated strings (caller frees all).
+pub fn extractModelIds(allocator: std.mem.Allocator, json_bytes: []const u8) ![][]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+
+    const root = parsed.value;
+    const models = root.object.get("models") orelse return error.InvalidResponse;
+    const arr = models.array orelse return error.InvalidResponse;
+
+    var list = std.ArrayList([]u8).init(allocator);
+    defer list.deinit();
+
+    for (arr.items) |item| {
+        const obj = item.object orelse continue;
+        const name_val = obj.get("name") orelse continue;
+        const name_str = name_val.string orelse continue;
+        const dup = try allocator.dupe(u8, name_str);
+        try list.append(dup);
+    }
+
+    return try list.toOwnedSlice();
+}


### PR DESCRIPTION
## Summary
- add Gemini API helpers for text generation and model listing
- wire new Gemini module into build system
- document Gemini usage and build integration

## Testing
- `zig build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6cc6c35c83329d9596185c8eeefd